### PR TITLE
Fix code scanning alert no. 88: Database query built from user-controlled sources

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -126,7 +126,7 @@ router.delete('/deleteUser', authMiddleware, isAuthorizedDeleting, csrfMiddlewar
         }
 
         if(user.company === req.session.user.company && !user.initialUser || req.session.user.appAdmin && !user.initialUser){
-            const result = await User.deleteOne({ _id: user._id });
+            const result = await User.deleteOne({ _id: { $eq: user._id } });
         }
 
         if (result.deletedCount === 1) {


### PR DESCRIPTION
Fixes [https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/88](https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/88)

To fix the problem, we need to ensure that the `user._id` is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the value is interpreted as a literal and not as a query object. This change will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
