### PR TITLE
Fix code scanning alert no. 87: Database query built from user-controlled sources

### DIFF
--- a/services/generateRegisterKey.js
+++ b/services/generateRegisterKey.js
@@ -12,7 +12,7 @@ async function generateRegisterKey(req, res){
     }
     else{
         console.log("Checking if company register key exists...");
-        existingRegisterKey = await registerKeyModel.findOne({Company: req.body.companyId});
+        existingRegisterKey = await registerKeyModel.findOne({Company: { $eq: req.body.companyId }});
         console.log("Company register key exists:", existingRegisterKey != null);
     }
 


### PR DESCRIPTION
Fixes [https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/87](https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/87)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `companyId` is treated as a literal value, preventing any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
