### PR TITLE
Fix code scanning alert no. 86: Database query built from user-controlled sources

### DIFF
--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -712,7 +712,7 @@ router.put("/allowedOrigins", authMiddleware, csrfMiddleware.validateCSRFToken, 
         let origin = req.body.allowedOrigin;
         let isOriginDeleted = false;
         try {
-            let originExists = await AllowedOriginModel.findOne({ allowedOrigin: origin });
+            let originExists = await AllowedOriginModel.findOne({ allowedOrigin: { $eq: origin } });
             let companyId = originExists.companies[0];
             if (!isRelatedToCompany(req, companyId)) {
                 return res.status(401).json({ message: "Unauthorized" });


### PR DESCRIPTION
Fixes [https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/86](https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/86)

To fix the problem, we need to ensure that the user input is properly sanitized or validated before being used in the database query. The best way to fix this issue is to use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
