### PR TITLE
Fix code scanning alert no. 84: Database query built from user-controlled sources

### DIFF
--- a/services/deleteAllCompanyRelation.js
+++ b/services/deleteAllCompanyRelation.js
@@ -49,7 +49,7 @@ async function deleteEverythingFromCompany(companyId) {
         console.log(`Finished deleting api key relations for company ID: ${company.companyId}`)
 
         console.log(`Deleting company: ${company.name}`)
-        await CompanyModel.deleteOne({ companyId: companyId })
+        await CompanyModel.deleteOne({ companyId: { $eq: companyId } })
         console.log(`Finished deleting company: ${company.name}`)
 
     } catch (error) {


### PR DESCRIPTION
Fixes [https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/84](https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/84)

To fix the problem, we need to ensure that the `companyId` is properly sanitized or validated before being used in the MongoDB query. The best way to fix this is to use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
