### PR TITLE
Fix code scanning alert no. 83: Database query built from user-controlled sources

### DIFF
--- a/services/deleteAllCompanyRelation.js
+++ b/services/deleteAllCompanyRelation.js
@@ -10,7 +10,11 @@ const deleteApiKeyRelation = require("../services/deleteApiKeyRelation.js")
 async function deleteEverythingFromCompany(companyId) {
     try {
         console.log(`Deleting all company relations with company ID: ${companyId}`)
-        const company = await CompanyModel.findOne({ companyId: companyId })
+        if (typeof companyId !== "string") {
+            console.log("Invalid company ID")
+            return { success: false, message: "Invalid company ID" }
+        }
+        const company = await CompanyModel.findOne({ companyId: { $eq: companyId } })
         console.log(`Found company: ${company ? company.name : "not found"}`)
         if (!company) {
             console.log("Company not found")
@@ -49,7 +53,7 @@ async function deleteEverythingFromCompany(companyId) {
         console.log(`Finished deleting api key relations for company ID: ${company.companyId}`)
 
         console.log(`Deleting company: ${company.name}`)
-        await CompanyModel.deleteOne({ companyId: companyId })
+        await CompanyModel.deleteOne({ companyId: { $eq: companyId } })
         console.log(`Finished deleting company: ${company.name}`)
 
     } catch (error) {


### PR DESCRIPTION
Fixes [https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/83](https://github.com/Drawing-Captcha/Drawing-Captcha-APP/security/code-scanning/83)

To fix the problem, we need to ensure that the `companyId` is treated as a literal value in the MongoDB query to prevent NoSQL injection. This can be achieved by using the `$eq` operator in the query. Additionally, we should validate that `companyId` is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
